### PR TITLE
Add 'fullversion' Print Argument

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ ocmtoc changelog
 #### v1.0.4
 - Rebased to cctools 1024.3
 - Added `__SBAT` support, thx @dakanji
+- Added `--fullversion` argument, thx @dakanji
 
 #### v1.0.3
 - Verify `__RO_RELOCS` protection level

--- a/efitools/mtoc.c
+++ b/efitools/mtoc.c
@@ -417,12 +417,12 @@ char **envp)
 	    	require_read_only_relocs = TRUE;
 	    }
 	    else if(strcmp(argv[i], "--version") == 0){
-	    	printf("%s\n", VERSION);
+	    	puts(VERSION);
 	    	exit(0);
 	    }
 	    else if(strcmp(argv[i], "--fullversion") == 0){
-            printf("Acidanthera ocmtoc %s\n", VERSION);
-            exit(0);
+	    	puts("Acidanthera ocmtoc " VERSION);
+	    	exit(0);
 	    }
 	    else if(input == NULL)
 		input = argv[i];

--- a/efitools/mtoc.c
+++ b/efitools/mtoc.c
@@ -23,6 +23,8 @@
 #define __eip eip
 #define __rip rip
 
+#define VERSION "1.0.4"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -415,8 +417,12 @@ char **envp)
 	    	require_read_only_relocs = TRUE;
 	    }
 	    else if(strcmp(argv[i], "--version") == 0){
-	    	printf("1.0.4\n");
+	    	printf("%s\n", VERSION);
 	    	exit(0);
+	    }
+	    else if(strcmp(argv[i], "--fullversion") == 0){
+            printf("Acidanthera ocmtoc %s\n", VERSION);
+            exit(0);
 	    }
 	    else if(input == NULL)
 		input = argv[i];


### PR DESCRIPTION
Allows accepting a `--fullversion` argument to output information that permits definitively determining ocmtoc use, bearing in mind that ocmtoc and mtoc share the same binary name.

The output string for the next release would be `Acidanthera ocmtoc 1.0.4`